### PR TITLE
Corrigido endpoint de /customers para /clients

### DIFF
--- a/src/main/kotlin/ams/repository/ClientRepository.kt
+++ b/src/main/kotlin/ams/repository/ClientRepository.kt
@@ -4,4 +4,5 @@ import ams.model.Client
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ClientRepository : JpaRepository<Client, Long> {
+    fun findAllByOrderByIdAsc(): List<Client>
 }

--- a/src/main/kotlin/ams/service/ClientService.kt
+++ b/src/main/kotlin/ams/service/ClientService.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service
 class ClientService(val repository: ClientRepository) {
 
     fun getAllClients(): List<Client> {
-        return repository.findAll().takeUnless { it.isEmpty() } ?: throw ClientNotFoundException("No clients found")
+        return repository.findAllByOrderByIdAsc().takeUnless { it.isEmpty() } ?: throw ClientNotFoundException("No clients found")
     }
 
     fun getClientById(id: Long): Client {

--- a/src/main/kotlin/ams/view/controller/ClientController.kt
+++ b/src/main/kotlin/ams/view/controller/ClientController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("api/v1/customers")
+@RequestMapping("api/v1/clients")
 class ClientController(val facade: ClientFacade) {
 
     @GetMapping

--- a/src/test/kotlin/ams/service/ClientServiceTest.kt
+++ b/src/test/kotlin/ams/service/ClientServiceTest.kt
@@ -27,7 +27,7 @@ class ClientServiceTest() {
     fun `should return all customers`() {
         // Given
         val clients = TestFixtures.createTestDataBuilderForClientList()
-        `when`(repository.findAll()).thenReturn(clients)
+        `when`(repository.findAllByOrderByIdAsc()).thenReturn(clients)
 
         // When
         val result = service.getAllClients()
@@ -35,13 +35,15 @@ class ClientServiceTest() {
         // Then
         assert(result == clients)
         assertEquals(TestFixtures.VALID_ID, clients[0].id)
+        assertEquals(TestFixtures.VALID_ID + 1, clients[1].id)
+        assertEquals(TestFixtures.VALID_ID + 2, clients[2].id)
         assertEquals(3, clients.size)
     }
 
     @Test
     fun `should return empty list`() {
         // Given
-        `when`(repository.findAll()).thenReturn(emptyList())
+        `when`(repository.findAllByOrderByIdAsc()).thenReturn(emptyList())
 
         // When
         val exception = assertThrows<ClientNotFoundException> {
@@ -79,4 +81,5 @@ class ClientServiceTest() {
         // Then
         assertEquals("Client with id 10 not found", exception.message)
     }
+
 }

--- a/src/test/kotlin/ams/view/controller/ClientControllerTest.kt
+++ b/src/test/kotlin/ams/view/controller/ClientControllerTest.kt
@@ -30,7 +30,7 @@ class ClientControllerTest() {
         `when`(clientFacade.getAllCustomers()).thenReturn(clients)
 
         // Act & Assert
-        mockMvc.perform(get("/api/v1/customers")
+        mockMvc.perform(get("/api/v1/clients")
             .accept(MediaType.APPLICATION_JSON))
             .andDo(print())
             .andExpect(status().isOk)
@@ -49,7 +49,7 @@ class ClientControllerTest() {
         `when`(clientFacade.getAllCustomers()).thenThrow(ClientNotFoundException("No clients found"))
 
         // Act & Assert
-        mockMvc.perform(get("/api/v1/customers")
+        mockMvc.perform(get("/api/v1/clients")
             .accept(MediaType.APPLICATION_JSON))
             .andDo(print())
             .andExpect(status().isNotFound)


### PR DESCRIPTION
Corrigido url do endpoint de Clients, pois anteriormente havia chamado de Customer e não havia mudado o endpoint para /clients